### PR TITLE
Added the support of Custom Server URL during the signup process.

### DIFF
--- a/lib/core/network/api_helper.dart
+++ b/lib/core/network/api_helper.dart
@@ -13,6 +13,7 @@ import 'package:http/http.dart' as http;
 class ApiHelper {
   late final String _hostDefault, _portAuth, _portDefault, _suffix;
   String? _hostOverride;
+  String? _portOverride;
   Map<String, String> get _headers => {'Content-Type': 'application/json'};
 
   late final PersistentIoClient client;
@@ -33,10 +34,24 @@ class ApiHelper {
   }
 
   String get host => _hostOverride?.isNotEmpty == true ? _hostOverride! : _hostDefault;
-
+  String? get portOverride => _portOverride;
   void setCustomHost(String? host) {
     final trimmed = host?.trim();
-    _hostOverride = trimmed == null || trimmed.isEmpty ? null : trimmed;
+    if (trimmed == null || trimmed.isEmpty) {
+      _hostOverride = null;
+      _portOverride = null;
+      return;
+    }
+
+    final parts = trimmed.split(':');
+    if (parts.length == 2) {
+      _hostOverride = parts[0];
+      _portOverride = parts[1];
+      return;
+    }
+
+    _hostOverride = trimmed;
+    _portOverride = null;
   }
 
   Future<void> loadCustomHost(SharedPreferencesHelper preferencesHelper) async {
@@ -75,7 +90,12 @@ class ApiHelper {
       throw ApiException('out_of_coverage', isOutOfCoverage: true);
     }
     String hostName = host;
-    if (path == ApiConstants.login) {
+    final overridePort = portOverride;
+    if (path == ApiConstants.signup &&
+        overridePort != null &&
+        overridePort.isNotEmpty) {
+      hostName += ':$overridePort';
+    } else if (path == ApiConstants.login) {
       hostName += ':${_portAuth}';
     } else {
       hostName += ':${_portDefault}';

--- a/lib/core/network/api_helper.dart
+++ b/lib/core/network/api_helper.dart
@@ -6,28 +6,42 @@ import 'package:family_wifi/core/network/api_constants.dart';
 import 'package:family_wifi/core/network/api_exception.dart';
 import 'package:family_wifi/core/network/persistent_io_client.dart';
 import 'package:family_wifi/core/utils/print_log_helper.dart';
+import 'package:family_wifi/core/utils/shared_preferences_helper.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
 class ApiHelper {
-  late final String _host, _portAuth, _portDefault, _suffix;
+  late final String _hostDefault, _portAuth, _portDefault, _suffix;
+  String? _hostOverride;
   Map<String, String> get _headers => {'Content-Type': 'application/json'};
 
   late final PersistentIoClient client;
 
   ApiHelper() {
     if (ApiConstants.developmentMode) {
-      _host = ApiConstants.baseUrlDev;
+      _hostDefault = ApiConstants.baseUrlDev;
       _suffix = ApiConstants.suffixDev;
       _portAuth = ApiConstants.authPortDev;
       _portDefault = ApiConstants.defaultPortDev;
     } else {
-      _host = ApiConstants.baseUrl;
+      _hostDefault = ApiConstants.baseUrl;
       _suffix = ApiConstants.suffix;
       _portAuth = ApiConstants.authPort;
       _portDefault = ApiConstants.defaultPort;
     }
     initClient();
+  }
+
+  String get host => _hostOverride?.isNotEmpty == true ? _hostOverride! : _hostDefault;
+
+  void setCustomHost(String? host) {
+    final trimmed = host?.trim();
+    _hostOverride = trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+
+  Future<void> loadCustomHost(SharedPreferencesHelper preferencesHelper) async {
+    final stored = await preferencesHelper.customServerUrl;
+    setCustomHost(stored);
   }
 
   void initClient() {
@@ -60,7 +74,7 @@ class ApiHelper {
     if (!await check()) {
       throw ApiException('out_of_coverage', isOutOfCoverage: true);
     }
-    String hostName = _host;
+    String hostName = host;
     if (path == ApiConstants.login) {
       hostName += ':${_portAuth}';
     } else {

--- a/lib/core/utils/shared_preferences_helper.dart
+++ b/lib/core/utils/shared_preferences_helper.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 class SharedPreferencesHelper {
   static const _firstRun = 'firstRun';
   static const _accessToken = 'accessToken';
+  static const _customServerUrl = 'customServerUrl';
 
   late final SharedPreferencesAsync _sharedPreference;
 
@@ -55,6 +56,17 @@ class SharedPreferencesHelper {
       iOptions: _getIosOptions(),
     );
     return storage.delete(key: _accessToken);
+  }
+
+  Future<void> setCustomServerUrl(String value) async {
+    return _sharedPreference.setString(_customServerUrl, value);
+  }
+
+  Future<String?> get customServerUrl =>
+      _sharedPreference.getString(_customServerUrl);
+
+  Future<void> removeCustomServerUrl() async {
+    return _sharedPreference.remove(_customServerUrl);
   }
 
   void dispose() {}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,8 +60,15 @@ class MyApp extends StatelessWidget {
 
   List<SingleChildWidget> _buildProviders() {
     return [
-      Provider<ApiHelper>(create: (_) => ApiHelper()),
       Provider(create: (_) => SharedPreferencesHelper()),
+      ProxyProvider<SharedPreferencesHelper, ApiHelper>(
+        update: (_, sharedPreferencesHelper, apiHelper) {
+          final helper = apiHelper ?? ApiHelper();
+          // ignore: unawaited_futures
+          helper.loadCustomHost(sharedPreferencesHelper);
+          return helper;
+        },
+      ),
     ];
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,17 +11,33 @@ import 'package:provider/single_child_widget.dart';
 import 'core/app_export.dart';
 
 var globalMessengerKey = GlobalKey<ScaffoldMessengerState>();
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   // 🚨 CRITICAL: Device orientation lock - DO NOT REMOVE
-  Future.wait([
-    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]),
-  ]).then((value) {
-    runApp(MyApp());
-  });
+  await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+
+  final sharedPreferencesHelper = SharedPreferencesHelper();
+  final apiHelper = ApiHelper();
+  await apiHelper.loadCustomHost(sharedPreferencesHelper);
+
+  runApp(
+    MyApp(
+      sharedPreferencesHelper: sharedPreferencesHelper,
+      apiHelper: apiHelper,
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
+  final SharedPreferencesHelper sharedPreferencesHelper;
+  final ApiHelper apiHelper;
+
+  const MyApp({
+    super.key,
+    required this.sharedPreferencesHelper,
+    required this.apiHelper,
+  });
+
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
@@ -60,15 +76,8 @@ class MyApp extends StatelessWidget {
 
   List<SingleChildWidget> _buildProviders() {
     return [
-      Provider(create: (_) => SharedPreferencesHelper()),
-      ProxyProvider<SharedPreferencesHelper, ApiHelper>(
-        update: (_, sharedPreferencesHelper, apiHelper) {
-          final helper = apiHelper ?? ApiHelper();
-          // ignore: unawaited_futures
-          helper.loadCustomHost(sharedPreferencesHelper);
-          return helper;
-        },
-      ),
+      Provider.value(value: sharedPreferencesHelper),
+      Provider.value(value: apiHelper),
     ];
   }
 

--- a/lib/presentation/sign_up_screen/models/sign_up_model.dart
+++ b/lib/presentation/sign_up_screen/models/sign_up_model.dart
@@ -6,25 +6,30 @@ class SignUpModel {
     this.email,
     this.operatorId,
     this.macAddress,
+    this.serverUrl,
   }) {
     email = email ?? '';
     operatorId = operatorId ?? '';
     macAddress = macAddress ?? '';
+    serverUrl = serverUrl ?? '';
   }
 
   String? email;
   String? operatorId;
   String? macAddress;
+  String? serverUrl;
 
   SignUpModel copyWith({
     String? email,
     String? operatorId,
     String? macAddress,
+    String? serverUrl,
   }) {
     return SignUpModel(
       email: email ?? this.email,
       operatorId: operatorId ?? this.operatorId,
       macAddress: macAddress ?? this.macAddress,
+      serverUrl: serverUrl ?? this.serverUrl,
     );
   }
 }

--- a/lib/presentation/sign_up_screen/models/sign_up_model.dart
+++ b/lib/presentation/sign_up_screen/models/sign_up_model.dart
@@ -6,30 +6,25 @@ class SignUpModel {
     this.email,
     this.operatorId,
     this.macAddress,
-    this.serverUrl,
   }) {
     email = email ?? '';
     operatorId = operatorId ?? '';
     macAddress = macAddress ?? '';
-    serverUrl = serverUrl ?? '';
   }
 
   String? email;
   String? operatorId;
   String? macAddress;
-  String? serverUrl;
 
   SignUpModel copyWith({
     String? email,
     String? operatorId,
     String? macAddress,
-    String? serverUrl,
   }) {
     return SignUpModel(
       email: email ?? this.email,
       operatorId: operatorId ?? this.operatorId,
       macAddress: macAddress ?? this.macAddress,
-      serverUrl: serverUrl ?? this.serverUrl,
     );
   }
 }

--- a/lib/presentation/sign_up_screen/provider/sign_up_provider.dart
+++ b/lib/presentation/sign_up_screen/provider/sign_up_provider.dart
@@ -18,7 +18,6 @@ class SignUpProvider with BaseBloc {
   TextEditingController operatorIdController = TextEditingController();
   TextEditingController macAddressController = TextEditingController();
   TextEditingController customServerUrlController = TextEditingController();
-
   late final SignUpRepository _repository;
   late final SharedPreferencesHelper _sharedPreferencesHelper;
   late final ApiHelper _apiHelper;
@@ -48,7 +47,8 @@ class SignUpProvider with BaseBloc {
         ApiConstants.developmentMode
             ? ApiConstants.baseUrlDev
             : ApiConstants.baseUrl;
-    final serverUrl = storedServerUrl?.trim();
+    String? serverUrl = storedServerUrl?.trim();
+
     customServerUrlController.text =
         serverUrl == null || serverUrl.isEmpty ? defaultServerUrl : serverUrl;
     _apiHelper.setCustomHost(customServerUrlController.text.trim());
@@ -93,13 +93,47 @@ class SignUpProvider with BaseBloc {
     if (trimmed.isEmpty) {
       return 'Server URL is required';
     }
-    if (trimmed.contains('://') || trimmed.contains('/') || trimmed.contains(':')) {
-      return 'Enter server URL like openwifi3.routerarchitects.com';
+
+    if (trimmed.contains('://') ||
+        trimmed.contains('/') ||
+        trimmed.contains('?') ||
+        trimmed.contains('#')) {
+      return 'Enter hostname or hostname:port only';
     }
+
+    final normalized = _normalizeServerUrl(trimmed);
+    if (normalized.isEmpty) {
+      return 'Enter a valid hostname';
+    }
+
+    final parts = normalized.split(':');
+    if (parts.length > 2) {
+      return 'Enter hostname or hostname:port only';
+    }
+
+    final host = parts[0];
+    final port = parts.length == 2 ? parts[1] : null;
+
+    if (host.isEmpty) {
+      return 'Enter a valid hostname';
+    }
+
     final hostRegex = RegExp(r'^[A-Za-z0-9.-]+$');
-    if (!hostRegex.hasMatch(trimmed) || !trimmed.contains('.')) {
-      return 'Enter a valid server URL';
+    final fqdnRegex =
+        RegExp(r'^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$');
+    final isFqdn = hostRegex.hasMatch(host) && fqdnRegex.hasMatch(host);
+
+    if (!isFqdn) {
+      return 'Enter a valid fully qualified domain name';
     }
+
+    if (port != null) {
+      final portNumber = int.tryParse(port);
+      if (portNumber == null || portNumber < 1 || portNumber > 65535) {
+        return 'Enter a valid port (1-65535)';
+      }
+    }
+
     return null;
   }
 
@@ -126,7 +160,6 @@ class SignUpProvider with BaseBloc {
       final normalizedServerUrl = _normalizeServerUrl(
         customServerUrlController.text,
       );
-      signUpModel.serverUrl = normalizedServerUrl;
       await _sharedPreferencesHelper.setCustomServerUrl(normalizedServerUrl);
       _apiHelper.setCustomHost(normalizedServerUrl);
 

--- a/lib/presentation/sign_up_screen/provider/sign_up_provider.dart
+++ b/lib/presentation/sign_up_screen/provider/sign_up_provider.dart
@@ -1,8 +1,11 @@
+import 'package:family_wifi/core/network/api_constants.dart';
+import 'package:family_wifi/core/network/api_helper.dart';
 import 'package:family_wifi/core/network/result.dart';
 import 'package:family_wifi/core/utils/alert_state_provider.dart';
 import 'package:family_wifi/core/utils/base_bloc.dart';
 import 'package:family_wifi/core/utils/loading_state_provider.dart';
 import 'package:family_wifi/core/utils/navigator_service.dart';
+import 'package:family_wifi/core/utils/shared_preferences_helper.dart';
 import 'package:family_wifi/l10n/app_localization_extension.dart';
 import 'package:family_wifi/presentation/sign_up_screen/models/sign_up_model.dart';
 import 'package:family_wifi/presentation/sign_up_screen/repository/sign_up_repository.dart';
@@ -14,13 +17,18 @@ class SignUpProvider with BaseBloc {
   TextEditingController emailController = TextEditingController();
   TextEditingController operatorIdController = TextEditingController();
   TextEditingController macAddressController = TextEditingController();
+  TextEditingController customServerUrlController = TextEditingController();
 
   late final SignUpRepository _repository;
+  late final SharedPreferencesHelper _sharedPreferencesHelper;
+  late final ApiHelper _apiHelper;
 
   SignUpProvider(
     LoadingStateProvider loadingStateProvider,
     AlertStateProvider alertStateProvider,
     this._repository,
+    this._sharedPreferencesHelper,
+    this._apiHelper,
   ) {
     initialize(loadingStateProvider, alertStateProvider);
   }
@@ -30,11 +38,20 @@ class SignUpProvider with BaseBloc {
     emailController.dispose();
     operatorIdController.dispose();
     macAddressController.dispose();
+    customServerUrlController.dispose();
     super.dispose();
   }
 
-  void init() {
-    // Add any initializations here
+  Future<void> init() async {
+    final storedServerUrl = await _sharedPreferencesHelper.customServerUrl;
+    final defaultServerUrl =
+        ApiConstants.developmentMode
+            ? ApiConstants.baseUrlDev
+            : ApiConstants.baseUrl;
+    final serverUrl = storedServerUrl?.trim();
+    customServerUrlController.text =
+        serverUrl == null || serverUrl.isEmpty ? defaultServerUrl : serverUrl;
+    _apiHelper.setCustomHost(customServerUrlController.text.trim());
   }
 
   String? validateEmail(String? value) {
@@ -71,6 +88,25 @@ class SignUpProvider with BaseBloc {
     return null;
   }
 
+  String? validateServerUrl(String? value) {
+    final trimmed = value?.trim() ?? '';
+    if (trimmed.isEmpty) {
+      return 'Server URL is required';
+    }
+    if (trimmed.contains('://') || trimmed.contains('/') || trimmed.contains(':')) {
+      return 'Enter server URL like openwifi3.routerarchitects.com';
+    }
+    final hostRegex = RegExp(r'^[A-Za-z0-9.-]+$');
+    if (!hostRegex.hasMatch(trimmed) || !trimmed.contains('.')) {
+      return 'Enter a valid server URL';
+    }
+    return null;
+  }
+
+  String _normalizeServerUrl(String value) {
+    return value.trim().toLowerCase();
+  }
+
   Future<void> onNextPressed(GlobalKey<FormState> formKey) async {
     if (!formKey.currentState!.validate()) {
       return;
@@ -86,6 +122,13 @@ class SignUpProvider with BaseBloc {
       signUpModel.macAddress = macAddressController.text
           .replaceAll(specialChars, '')
           .toLowerCase();
+
+      final normalizedServerUrl = _normalizeServerUrl(
+        customServerUrlController.text,
+      );
+      signUpModel.serverUrl = normalizedServerUrl;
+      await _sharedPreferencesHelper.setCustomServerUrl(normalizedServerUrl);
+      _apiHelper.setCustomHost(normalizedServerUrl);
 
       Result result = await _repository.createAccount(signUpModel);
 

--- a/lib/presentation/sign_up_screen/sign_up_screen.dart
+++ b/lib/presentation/sign_up_screen/sign_up_screen.dart
@@ -1,6 +1,7 @@
 import 'package:family_wifi/core/network/api_helper.dart';
 import 'package:family_wifi/core/utils/alert_state_provider.dart';
 import 'package:family_wifi/core/utils/loading_state_provider.dart';
+import 'package:family_wifi/core/utils/shared_preferences_helper.dart';
 import 'package:family_wifi/main.dart';
 import 'package:family_wifi/presentation/sign_up_screen/repository/sign_up_repository.dart';
 import 'package:family_wifi/widgets/style_helper.dart';
@@ -22,16 +23,32 @@ class SignUpScreen extends StatefulWidget {
           return signUpRepo ?? SignUpRepository(apiHelper);
         },
         child:
-            ProxyProvider3<
+            ProxyProvider5<
               LoadingStateProvider,
               AlertStateProvider,
               SignUpRepository,
+              SharedPreferencesHelper,
+              ApiHelper,
               SignUpProvider
             >(
               update:
-                  (_, loadingState, alertState, signUpRepo, signUpProvider) {
+                  (
+                    _,
+                    loadingState,
+                    alertState,
+                    signUpRepo,
+                    sharedPreferencesHelper,
+                    apiHelper,
+                    signUpProvider,
+                  ) {
                     return signUpProvider ??
-                        SignUpProvider(loadingState, alertState, signUpRepo);
+                        SignUpProvider(
+                          loadingState,
+                          alertState,
+                          signUpRepo,
+                          sharedPreferencesHelper,
+                          apiHelper,
+                        );
                   },
               child: const SignUpScreen(),
             ),
@@ -138,6 +155,13 @@ class _SignUpScreenState extends State<SignUpScreen> {
                         hintText: 'MAC address of first router',
                         backgroundColor: appTheme.blue_gray_900,
                         validator: controller.validateMacAddress,
+                      ),
+                      SizedBox(height: 24.h),
+                      CustomEditText(
+                        controller: controller.customServerUrlController,
+                        hintText: 'Server URL',
+                        backgroundColor: appTheme.blue_gray_900,
+                        validator: controller.validateServerUrl,
                       ),
                     ],
                   ),

--- a/lib/presentation/sign_up_screen/sign_up_screen.dart
+++ b/lib/presentation/sign_up_screen/sign_up_screen.dart
@@ -71,7 +71,11 @@ class _SignUpScreenState extends State<SignUpScreen> {
     controller.loadingStateProvider.addListener(handleLoadingState);
     controller.alertStateProvider.addListener(handleAlertState);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      controller.init();
+      controller.init().then((_) {
+        if (mounted) {
+          setState(() {});
+        }
+      });
     });
   }
 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,13 +6,17 @@ import FlutterMacOS
 import Foundation
 
 import connectivity_plus
+import flutter_secure_storage_macos
 import path_provider_foundation
 import shared_preferences_foundation
 import sqflite_darwin
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -513,10 +513,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -894,10 +894,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
***Issue***
#10 

**Feature description:-**
Added support for selecting a custom backend server host during the signup process. The server host entered by the user will be shown on the signup screen as an editable field.

**Test Steps:**
1. Open the WiFi-Home Network application.

2. Click on Sign Up.
<img width="497" height="918" alt="Screenshot from 2026-02-10 17-56-04" src="https://github.com/user-attachments/assets/ddfe827f-5f72-4d82-a3ca-0629686d376f" />

3. By default, it should be pre-filled with default the server URL [openwifi3.routerarchitects.com](url).
<img width="497" height="918" alt="Screenshot from 2026-02-10 17-54-29" src="https://github.com/user-attachments/assets/1d313051-c947-4226-bbf4-2dffe763cffe" />

4. Add the custom URL. It should be working.
<img width="497" height="918" alt="Screenshot from 2026-02-10 17-52-50" src="https://github.com/user-attachments/assets/f74b6b90-9a65-40ed-8f68-cae90af62046" />